### PR TITLE
Load icu from tarantool and not from external libraries

### DIFF
--- a/icu-date.lua
+++ b/icu-date.lua
@@ -2,14 +2,9 @@ local ffi = require("ffi")
 local detect_icu_version_suffix = require("icu-date.detect_icu_version_suffix")
 local icu_ffi_cdef = require("icu-date.ffi_cdef")
 
-local icu_version_suffix, fullpath = detect_icu_version_suffix()
+local icu_version_suffix = detect_icu_version_suffix()
 icu_ffi_cdef(ffi, icu_version_suffix)
-local icu
-if fullpath ~= nil then
-    icu = ffi.load(fullpath)
-else
-    icu = ffi.load("icui18n")
-end
+local icu = ffi.C
 
 local uerrorcode_type = ffi.typeof("UErrorCode[1]")
 local uchar_size = ffi.sizeof("UChar")


### PR DESCRIPTION
Since we use icu inside tarantool, we may just load it using ffi.C.
This also works well when using statically linked version of tarantool,
because there is no libicu in the system.