### PR TITLE
add locale parameter to format function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ date:format(format_iso8601) -- "2017-10-12T19:32:07.123Z"
 local format_custom = icu_date.formats.pattern("EEE, MMM d, yyyy h:mma zzz")
 date:format(format_custom) -- "Thu, Oct 12, 2017 7:32PM GMT"
 
+-- You can generate a custom formatted string the necessary locale.
+local format_custom = icu_date.formats.pattern("d MMMM y", "ru_RU")
+date:format(format_custom) -- "12 октября 2017"
+
 -- You can parse a string using various formats.
 local format_date = icu_date.formats.pattern("yyyy-MM-dd")
 date:parse(format_date, "2016-09-18")
@@ -91,7 +95,9 @@ The `options` table accepts the following fields:
 
 ### formats.pattern
 
-**syntax:** `format = icu_date.formats.pattern(pattern)`
+**syntax:** `format = icu_date.formats.pattern(pattern, locale)`
+
+- `locale` is optional argument (default: `en_US`)
 
 ### formats.iso8601
 

--- a/icu-date.lua
+++ b/icu-date.lua
@@ -199,17 +199,20 @@ local function close_date_format(format)
   call_fn("udat_close", format)
 end
 
-function _M.formats.pattern(pattern)
-  if format_cache[pattern] then
-    return format_cache[pattern]
+function _M.formats.pattern(pattern, locale)
+  locale = locale or "en_US"
+  if format_cache[pattern] and format_cache[pattern][locale] then
+    return format_cache[pattern][locale]
   end
 
   local pattern_uchar = string_to_uchar(pattern)
   local status_ptr = ffi.new(uerrorcode_type)
-  local format = call_fn_check_status("udat_open", icu.UDAT_PATTERN, icu.UDAT_PATTERN, "en_US", nil, 0, pattern_uchar, -1, status_ptr)
+  local format = call_fn_check_status("udat_open", icu.UDAT_PATTERN, icu.UDAT_PATTERN, locale, nil, 0, pattern_uchar, -1, status_ptr)
   ffi.gc(format, close_date_format)
 
-  format_cache[pattern] = format
+  format_cache[pattern] = format_cache[pattern] or {}
+  format_cache[pattern][locale] = format
+
   return format
 end
 

--- a/test/test_format_spec.lua
+++ b/test/test_format_spec.lua
@@ -5,7 +5,7 @@ local icu_date = require('icu-date')
 local tap = require('tap')
 
 local test = tap.test("format")
-test:plan(2)
+test:plan(4)
 
 local function date_test(test, func)
     test:plan(2)
@@ -33,5 +33,18 @@ test:test("custom pattern format", date_test,
               test:ok("2017-10-12" == date:format(format))
 end)
 
+test:test("custom pattern format with ru_RU locale", date_test,
+          function(test, date, fields, format)
+              test:plan(1)
+              local format = icu_date.formats.pattern("d MMMM y", 'ru_RU')
+              test:ok("12 октября 2017" == date:format(format))
+end)
+
+test:test("custom pattern format with en_US locale", date_test,
+          function(test, date, fields, format)
+              test:plan(1)
+              local format = icu_date.formats.pattern("d MMMM y", 'en_US')
+              test:ok("12 October 2017" == date:format(format))
+end)
 
 return test:check()


### PR DESCRIPTION
Add `locale` parameter to `format` function.

By default this function used `en_US`, this patch allows to change this behaviour and saves backward compatibility.