### PR TITLE
disable lenient mode

### DIFF
--- a/icu-date.lua
+++ b/icu-date.lua
@@ -244,7 +244,7 @@ function _M.formats.pattern(pattern, locale)
       return nil, err
   end
   ffi.gc(format, close_date_format)
-
+  call_fn('udat_setLenient', format, false)
   format_cache[pattern] = format_cache[pattern] or {}
   format_cache[pattern][locale] = format
 

--- a/icu-date/ffi_cdef.lua
+++ b/icu-date/ffi_cdef.lua
@@ -7,6 +7,7 @@ return function(ffi, icu_version_suffix)
 
     typedef uint16_t UChar;
     typedef void* UCalendar;
+    typedef bool UBool;
     typedef double UDate;
     typedef void* UDateFormat;
     typedef enum UErrorCode {
@@ -260,6 +261,7 @@ return function(ffi, icu_version_suffix)
     const char* u_errorName]] .. icu_version_suffix .. [[(UErrorCode code);
 
     UDateFormat* udat_open]] .. icu_version_suffix .. [[(UDateFormatStyle timeStyle, UDateFormatStyle dateStyle, const char* locale, const UChar* tzID, int32_t tzIDLength, const UChar* pattern, int32_t patternLength, UErrorCode* status);
+    void udat_setLenient]] .. icu_version_suffix .. [[(UDateFormat* fmt, UBool isLenient);
     void udat_close]] .. icu_version_suffix .. [[(UDateFormat* format);
     void udat_parseCalendar]] .. icu_version_suffix .. [[(const UDateFormat* format, UCalendar* calendar, const UChar* text, int32_t textLength, int32_t* parsePos, UErrorCode* status);
     int32_t udat_formatCalendar]] .. icu_version_suffix .. [[(const UDateFormat* format, UCalendar* calendar, UChar* result, int32_t capacity, UFieldPosition* position, UErrorCode* status);

--- a/test/test_add_spec.lua
+++ b/test/test_add_spec.lua
@@ -47,4 +47,4 @@ test:test("wraps values", date_test,
               test:ok("2018-01-12T19:32:07.123Z" == date:format(format))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_clear_field.lua
+++ b/test/test_clear_field.lua
@@ -14,4 +14,4 @@ test:test("clear date filed", function(test)
   test:ok(0 == date:get(icu_date.fields.MILLISECOND))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_corner.lua
+++ b/test/test_corner.lua
@@ -42,4 +42,4 @@ test:isnt(true, status, "parse(\"adsd\", \"asdfasdf\", {})")
 local status, _ = pcall(function () d:parse(nil, "", {}) end)
 test:isnt(true, status, "parse(nil, \"\", {})")
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_err.lua
+++ b/test/test_err.lua
@@ -17,4 +17,4 @@ test:ok(ok == false, "Incorrect usage of icu-date.parse function")
 test:ok(err:endswith("Use date:parse(...) instead of date.parse(...)"),
                         "Incorrect usage of icu-date.parse function. Error message")
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_format_spec.lua
+++ b/test/test_format_spec.lua
@@ -47,4 +47,4 @@ test:test("custom pattern format with en_US locale", date_test,
               test:ok("12 October 2017" == date:format(format))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_get_attribute_spec.lua
+++ b/test/test_get_attribute_spec.lua
@@ -51,4 +51,4 @@ test:test("gets skipped wall time", date_test,
               test:ok(0 == date:get_attribute(attributes.SKIPPED_WALL_TIME))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_get_millis_spec.lua
+++ b/test/test_get_millis_spec.lua
@@ -26,4 +26,4 @@ test:test("gets milliseconds", date_test,
               test:ok(1507836727123 == date:get_millis())
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_get_spec.lua
+++ b/test/test_get_spec.lua
@@ -164,4 +164,4 @@ test:test("gets day of month", date_test,
               test:is(12, date:get(fields.DAY_OF_MONTH))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_new_spec.lua
+++ b/test/test_new_spec.lua
@@ -21,5 +21,4 @@ test:test("accepts zone_id", function(test)
               test:is("2017-10-12T13:32:07.123-06:00", date:format(format))
 end)
 
-
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_now_spec.lua
+++ b/test/test_now_spec.lua
@@ -13,4 +13,4 @@ test:test("get current time", function(test)
               test:is(type(now), 'number')
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_parse_spec.lua
+++ b/test/test_parse_spec.lua
@@ -89,4 +89,4 @@ test:test("parsing is not lenient",
               test:is(err, 'Invalid status: "U_PARSE_ERROR". Result: "nil"')
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_parse_spec.lua
+++ b/test/test_parse_spec.lua
@@ -5,7 +5,7 @@ local icu_date = require('icu-date')
 local tap = require('tap')
 
 local test = tap.test("parse")
-test:plan(6)
+test:plan(7)
 
 test:test("parses iso8601 date and time", function(test)
               test:plan(2)
@@ -66,6 +66,27 @@ test:test("can disable clearing date", function(test)
               local format = icu_date.formats.pattern("yyyy-MM-dd")
               date:parse(format, "2016-09-18", { clear = false })
               test:is("2016-09-18T19:32:07.123Z", date:format(icu_date.formats.iso8601()))
+end)
+
+--[[
+    By default, parsing is lenient: If the input is not in the form used by
+    this object's format method but can still be parsed as a date, then the
+    parse succeeds. Clients may insist on strict adherence to the format by
+    calling setLenient(false).
+    https://github.com/unicode-org/icu/blob/master/icu4c/source/i18n/unicode/datefmt.h
+--]]
+test:test("parsing is not lenient",
+          function(test)
+              test:plan(4)
+              local date = icu_date.new()
+              local format1 = icu_date.formats.pattern("yyyy-MM-dd")
+              local ok, err = date:parse(format1, "2016-13-18")
+              test:is(ok, nil)
+              test:is(err, 'Invalid status: "U_PARSE_ERROR". Result: "nil"')
+              local format2 = icu_date.formats.pattern('yyyyMMdd\'T\'HHmmss')
+              local ok, err = date:parse(format2, "q2020-50-50")
+              test:is(ok, nil)
+              test:is(err, 'Invalid status: "U_PARSE_ERROR". Result: "nil"')
 end)
 
 return test:check()

--- a/test/test_set_attribute_spec.lua
+++ b/test/test_set_attribute_spec.lua
@@ -66,4 +66,4 @@ test:test("sets skipped wall time", date_test,
               test:is("2017-10-12T19:32:07.123Z", date:format(format))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_set_millis_spec.lua
+++ b/test/test_set_millis_spec.lua
@@ -19,4 +19,4 @@ test:test("sets milliseconds", function(test)
               test:is("1970-01-01T00:00:01.000Z", date:format(format))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)

--- a/test/test_set_spec.lua
+++ b/test/test_set_spec.lua
@@ -238,4 +238,4 @@ test:test("sets day of month", date_test,
               test:is("2017-10-01T19:32:07.123Z", date:format(format))
 end)
 
-return test:check()
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
The cite from icu source code:
  | By default, parsing is lenient: If the input is not in the form used by
  | this object's format method but can still be parsed as a date, then the
  | parse succeeds. Clients may insist on strict adherence to the format by
  | calling setLenient(false).

https://github.com/unicode-org/icu/blob/master/icu4c/source/i18n/unicode/datefmt.h

It led to some confusing situations for users. This patch simply
set this flag by default to false.

Closes #16